### PR TITLE
Add rel='noopener noreferrer' to Synergy links

### DIFF
--- a/new-ui/scripts.js
+++ b/new-ui/scripts.js
@@ -152,7 +152,7 @@ $(document).ready(function(){
 		var url = "https://hcpss.me/synergy";
 	}
 	var label = "Synergy";
-	$('#extra-nav').append("<li class='menu-item' > <a id='link-synergy' href='" + url + "' class='menu-item-no-drop' target='_blank'>"+label+"</a> </li>");
+	$('#extra-nav').append("<li class='menu-item' > <a id='link-synergy' href='" + url + "' class='menu-item-no-drop' target='_blank' rel='noopener noreferrer'>"+label+"</a> </li>");
 
 	// GA tracking for all extra nav
 	/* 

--- a/old-ui/scripts.js
+++ b/old-ui/scripts.js
@@ -110,7 +110,7 @@ $(document).ready(function(){
 			var url = "https://hcpss.me/synergy";
 			var label = "Synergy";
 		}
-		$('#extra-nav').append("<li class='menu-item' > <a id='link-synergy' href='" + url + "' class='menu-item-no-drop' target='_blank'>"+label+"</a> </li>");
+		$('#extra-nav').append("<li class='menu-item' > <a id='link-synergy' href='" + url + "' class='menu-item-no-drop' target='_blank' rel='noopener noreferrer'>"+label+"</a> </li>");
 
 		/* Extra orientation link in nav for students/teachers */
 		var url = "https://hcpss.instructure.com/courses/9495";


### PR DESCRIPTION
Synergy popup windows fail because they are referencing the window opener. More information about this issue is detailed here, https://dev.to/ben/the-targetblank-vulnerability-by-example.